### PR TITLE
fix: defensive set var

### DIFF
--- a/tutorcredentials/templates/credentials/apps/credentials/settings/partials/common.py
+++ b/tutorcredentials/templates/credentials/apps/credentials/settings/partials/common.py
@@ -12,7 +12,7 @@ PROTOCOL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}"
 CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = []
 
-{% set jwt_rsa_key = rsa_import_key(JWT_RSA_PRIVATE_KEY) %}
+{% set jwt_rsa_key | rsa_import_key %}{{ JWT_RSA_PRIVATE_KEY }}{% endset %}
 JWT_AUTH["JWT_ISSUER"] = "{{ JWT_COMMON_ISSUER }}"
 JWT_AUTH["JWT_AUDIENCE"] = "{{ JWT_COMMON_AUDIENCE }}"
 JWT_AUTH["JWT_SECRET_KEY"] = "{{ JWT_COMMON_SECRET_KEY }}"


### PR DESCRIPTION
This change is patterned off of:

https://github.com/overhangio%7B%%20set%20jwt_rsa_key%20=%20rsa_import_key(JWT_RSA_PRIVATE_KEY)%20%%7D/tutor-ecommerce/commit/67728395d6ba359b3c4d675ca3b1ebb4fe9272a4

Similar report in 

https://discuss.openedx.org/t/error-while-tutor-local-qhttps://github.com/overhangio%7B%%20set%20jwt_rsa_key%20=%20rsa_import_key(JWT_RSA_PRIVATE_KEY)%20%%7D/tutor-ecommerce/commit/67728395d6ba359b3c4d675ca3b1ebb4fe9272a4uickstart/8796